### PR TITLE
Peg sanic to v22.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sanic
+sanic==22.6.2
 transformers
 torch
 ftfy


### PR DESCRIPTION
# What is this?
Peg sanic to v22.6.2

# Why?
The latest sanic version causes breaking changes — this has already been addressed in the other Banana templates